### PR TITLE
Missing --location value throws exception

### DIFF
--- a/setup-exercise.sh
+++ b/setup-exercise.sh
@@ -21,7 +21,7 @@ PLAN_NAME=myPlan
 printf "\nCreating App Service plan in FREE tier ... (2/7)\n\n"
 
 
-az appservice plan create --name $apiappname --resource-group $RESOURCE_GROUP --sku FREE --verbose
+az appservice plan create --name $apiappname --resource-group $RESOURCE_GROUP --sku FREE --verbose --location westeurope
 
 printf "\nCreating API App ... (3/7)\n\n"
 


### PR DESCRIPTION
Should specify value for location. Read from user input or add some default value. Otherwise this bash script doesn't work.